### PR TITLE
Pin pyarrow and document Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 Civic Pulse – Rochester
+
+## Setup
+
+This project targets **Python 3.11**, matching the version used in CI. Install the
+dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+Using newer Python versions may fail to install `pyarrow` because wheels are
+not always available.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyarrow
+pyarrow==14.0.1
 requests
 awswrangler
 pandas


### PR DESCRIPTION
## Summary
- document project setup in README
- mention failure to install `pyarrow` on newer Python versions
- pin pyarrow version in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_684afde8acb8832a9bc9d649f91a7203