### PR TITLE
Fix pydeck geometry serialization

### DIFF
--- a/webapp/pulse_app.py
+++ b/webapp/pulse_app.py
@@ -77,9 +77,10 @@ with left:
     # PyDeck choropleth
     scoreNorm_expr = "(properties.score - minScore) / (maxScore - minScore)"
 
+    geojson_data = json.loads(tract_gdf.to_json())
     layer = pdk.Layer(
         "GeoJsonLayer",
-        data=tract_gdf,
+        data=geojson_data,
         id="tract-layer",
         pickable=True,
         auto_highlight=True,


### PR DESCRIPTION
## Summary
- avoid pydeck serialization error by converting GeoDataFrame to GeoJSON before plotting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0ceb12fc832aa59a26c458897d49