### PR TITLE
Fix GeoJSON serialization error for date columns

### DIFF
--- a/webapp/pulse_app.py
+++ b/webapp/pulse_app.py
@@ -77,7 +77,9 @@ with left:
     # PyDeck choropleth
     scoreNorm_expr = "(properties.score - minScore) / (maxScore - minScore)"
 
-    geojson_data = json.loads(tract_gdf.to_json())
+    # GeoPandas can't directly serialise Python ``date`` objects.
+    # ``default=str`` converts them to ISO formatted strings for JSON output.
+    geojson_data = json.loads(tract_gdf.to_json(default=str))
     layer = pdk.Layer(
         "GeoJsonLayer",
         data=geojson_data,


### PR DESCRIPTION
## Summary
- ensure GeoJSON output works with date columns by passing `default=str`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b16b8e160832ab449150dadb9a498